### PR TITLE
Change container to run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,6 @@ RUN apt-get update && apt-get -y upgrade && \
     apt-get -y autoremove && \
     apt-get clean
 
-USER nobody
+#USER nobody
 ENTRYPOINT [ "/usr/local/bin/vzlogger" ]
 


### PR DESCRIPTION
The nobody user cannot access /dev/ttyUSB0 or similar devices.
Referencing the issue I opened: https://github.com/t3r/vzlogger-docker/issues/2
